### PR TITLE
VCST-4203: Remove obsolete code

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,4 +7,7 @@
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.916.0-alpha.13164-vcst-4203-cleanup" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.692" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.830.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.804.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0-alpha.1370-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.811.0-alpha.257-vcst-4203-cleanup" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AuthorizeNetPayment.Core\VirtoCommerce.AuthorizeNetPayment.Core.csproj" />

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.2.692" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0-alpha.1370-vcst-4203-cleanup" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.811.0-alpha.257-vcst-4203-cleanup" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.811.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AuthorizeNetPayment.Core\VirtoCommerce.AuthorizeNetPayment.Core.csproj" />

--- a/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.806.0</version>
   <version-tag />
 
-  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
+  <platformVersion>3.917.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Orders" version="3.863.0-alpha.1370-vcst-4203-cleanup" />
-    <dependency id="VirtoCommerce.Payment" version="3.811.0-alpha.257-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Orders" version="3.863.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.811.0" />
   </dependencies>
 
   <title>Authorize.Net Payment Method</title>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.806.0</version>
   <version-tag />
 
-  <platformVersion>3.853.0</platformVersion>
+  <platformVersion>3.916.0-alpha.13164-vcst-4203-cleanup</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Orders" version="3.830.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.804.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.863.0-alpha.1370-vcst-4203-cleanup" />
+    <dependency id="VirtoCommerce.Payment" version="3.811.0-alpha.257-vcst-4203-cleanup" />
   </dependencies>
 
   <title>Authorize.Net Payment Method</title>
@@ -25,7 +25,7 @@
   <iconUrl>Modules/$(VirtoCommerce.AuthorizeNetPayment)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <assemblyFile>VirtoCommerce.AuthorizeNetPayment.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.AuthorizeNetPayment.Web.Module, VirtoCommerce.AuthorizeNetPayment.Web</moduleType>

--- a/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
+++ b/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description

## References
### QA-test:

### Required modules list URL:
https://github.com/VirtoCommerce/vc-modules/raw/refs/heads/VCST-4203-cleanup/update/modules.json
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4203
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AuthorizeNetPayment_3.806.0-pr-10-9ffd.zip