### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-VirtoCommerce.AuthorizeNetPayment.sln

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "VirtoCommerce.AuthorizeNetPayment.sln"
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.807.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.917.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -266,7 +266,7 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                     Order = order,
                 };
 
-                var voidReult = await VoidProcessPaymentAsync(voidRequest);
+                var voidReult = await VoidProcessPaymentAsync(voidRequest, cancellationToken);
 
                 result.IsSuccess = voidReult.IsSuccess;
                 result.NewPaymentStatus = voidReult.NewPaymentStatus;

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -66,7 +66,7 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
         private string ProcessPaymentAction => Settings.GetValue<string>(ModuleConstants.Settings.General.ProcessPaymentAction);
 
 
-        public override Task<ProcessPaymentRequestResult> ProcessPaymentAsync(ProcessPaymentRequest request, CancellationToken cancellationToken = default)
+        public override async Task<ProcessPaymentRequestResult> ProcessPaymentAsync(ProcessPaymentRequest request, CancellationToken cancellationToken = default)
         {
             var tokenRequest = new AuthorizeNetTokenRequest
             {
@@ -75,7 +75,7 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                 TransactionKey = TransactionKey,
             };
 
-            var clientKeyResult = _authorizeNetClient.GetPublicClientKey(tokenRequest);
+            var clientKeyResult = await _authorizeNetClient.GetPublicClientKeyAsync(tokenRequest);
 
             var userIp = request.Parameters != null ? request.Parameters["True-Client-IP"] : string.Empty;
 

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -242,7 +242,7 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                     PaymentData = transactionDetails.PaymentData,
                 };
 
-                var refundTransactionResult = _authorizeNetClient.RefundTransaction(transactionRequest);
+                var refundTransactionResult = await _authorizeNetClient.RefundTransactionAsync(transactionRequest);
 
                 if (refundTransactionResult.TransactionResponse == TransactionResponse.Approved)
                 {

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -108,7 +108,7 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
             payment.PaymentStatus = PaymentStatus.Pending;
             payment.Status = payment.PaymentStatus.ToString();
 
-            return Task.FromResult(result);
+            return result;
         }
 
         public override async Task<PostProcessPaymentRequestResult> PostProcessPaymentAsync(PostProcessPaymentRequest request, CancellationToken cancellationToken = default)

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
@@ -18,10 +18,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DotLiquid" Version="2.2.692" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.863.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.811.0" />
+    <PackageReference Include="DotLiquid" Version="2.3.197" />
+    
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AuthorizeNetPayment.Core\VirtoCommerce.AuthorizeNetPayment.Core.csproj" />

--- a/src/VirtoCommerce.AuthorizeNetPayment.Web/VirtoCommerce.AuthorizeNetPayment.Web.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Web/VirtoCommerce.AuthorizeNetPayment.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.AuthorizeNetPayment</id>
-  <version>3.807.0</version>
+  <version>3.1000.0</version>
   <version-tag />
 
-  <platformVersion>3.917.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Orders" version="3.863.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.811.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
   </dependencies>
 
   <title>Authorize.Net Payment Method</title>
@@ -25,7 +25,7 @@
   <iconUrl>Modules/$(VirtoCommerce.AuthorizeNetPayment)/Content/logo.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <assemblyFile>VirtoCommerce.AuthorizeNetPayment.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.AuthorizeNetPayment.Web.Module, VirtoCommerce.AuthorizeNetPayment.Web</moduleType>

--- a/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
+++ b/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -8,10 +8,10 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AuthorizeNetPayment_3.1000.0-pr-11-d583.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Framework and dependency upgrades plus a switch to async payment method overrides can affect runtime behavior and integration compatibility, though the business logic is largely unchanged.
> 
> **Overview**
> Upgrades the module (core/data/web/tests) from `net8.0` to `net10.0`, bumps the module version to `3.1000.0`, and aligns `platformVersion`/module dependencies to the `3.1000.0`/`3.1002.0` VirtoCommerce line.
> 
> Updates `AuthorizeNetPaymentMethod` to the newer async payment pipeline (`ProcessPaymentAsync`, `PostProcessPaymentAsync`, capture/refund/void async variants) and switches Authorize.Net client calls to their async counterparts. Also refreshes supporting packages (e.g., `DotLiquid`, test SDK/xUnit v3) and adds `.nuke/parameters.json` for build configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d583e4eae2b980f0e6a1fa75a238531de29cce73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->