### PR TITLE
VCST-5162: Extend Authorize.NET with AllowCartPayment

### DIFF
--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -36,6 +36,8 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
 
         public override PaymentMethodType PaymentMethodType => PaymentMethodType.PreparedForm;
 
+        public override bool AllowCartPayment => true;
+
         private string ApiLogin => _options.ApiLogin;
 
         private string TransactionKey => _options.TxnKey;
@@ -104,9 +106,11 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                 }
             };
 
-            var payment = request.GetPayment();
-            payment.PaymentStatus = PaymentStatus.Pending;
-            payment.Status = payment.PaymentStatus.ToString();
+            if (request.GetPayment() is { } payment)
+            {
+                payment.PaymentStatus = PaymentStatus.Pending;
+                payment.Status = payment.PaymentStatus.ToString();
+            }
 
             return result;
         }

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -270,11 +270,11 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                     Order = order,
                 };
 
-                var voidReult = await VoidProcessPaymentAsync(voidRequest, cancellationToken);
+                var voidResult = await VoidProcessPaymentAsync(voidRequest, cancellationToken);
 
-                result.IsSuccess = voidReult.IsSuccess;
-                result.NewPaymentStatus = voidReult.NewPaymentStatus;
-                result.ErrorMessage = voidReult.ErrorMessage;
+                result.IsSuccess = voidResult.IsSuccess;
+                result.NewPaymentStatus = voidResult.NewPaymentStatus;
+                result.ErrorMessage = voidResult.ErrorMessage;
             }
 
             return result;

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/Providers/AuthorizeNetPaymentMethod.cs
@@ -348,9 +348,12 @@ namespace VirtoCommerce.AuthorizeNetPayment.Data.Providers
                     ProcessedDate = DateTime.UtcNow,
                     CurrencyCode = payment.Currency,
                     Amount = payment.Sum,
-                    Note = $"Transaction ID: {transactionResult.TransactionId}",
-                    Status = transactionMessage.Description,
-                    ResponseCode = transactionMessage.Code,
+                    // Status (64) and ResponseCode (64) are short columns. The gateway can return
+                    // several combined messages/warnings even on approval, so keep concise values
+                    // here and put the full text in Note (2048).
+                    Note = $"Transaction ID: {transactionResult.TransactionId}. {transactionMessage.Description}".Trim(),
+                    Status = transactionResult.TransactionResponse.ToString(),
+                    ResponseCode = transactionResult.TransactionResponseCode,
                     ResponseData = $"Account number {transactionResult.AccountNumber}",
                 };
 


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5162
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AuthorizeNetPayment_3.1001.0-pr-12-c821.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes payment method eligibility and how gateway responses are stored; incorrect mapping could affect transaction audit data, but core charge/capture logic is unchanged.
> 
> **Overview**
> Enables **Authorize.NET** for cart-level checkout by overriding **`AllowCartPayment`** to `true`, so the prepared-form method can be used before an order exists.
> 
> **`ProcessPaymentAsync`** now sets pending status only when **`request.GetPayment()`** returns a payment (avoids null reference when no payment is on the request). Refund path typo **`voidReult`** → **`voidResult`**.
> 
> On approved sale transactions, **`PaymentGatewayTransaction`** persistence is adjusted: **`Status`** and **`ResponseCode`** store short gateway enum/code values (64-char columns), while the full gateway message is appended to **`Note`** (2048) to avoid truncation when Authorize.NET returns long combined messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8213b8a509b209ae72b3676d45d622c10558331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->