### PR TITLE
VCST-5163: Stable 15 — AuthorizeNetPayment (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Core/VirtoCommerce.AuthorizeNetPayment.Core.csproj
@@ -8,6 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Data/VirtoCommerce.AuthorizeNetPayment.Data.csproj
@@ -20,8 +20,8 @@
   <ItemGroup>
     <PackageReference Include="DotLiquid" Version="2.3.197" />
     
-    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.OrdersModule.Core" Version="3.1009.0" />
+    <PackageReference Include="VirtoCommerce.PaymentModule.Core" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.AuthorizeNetPayment.Core\VirtoCommerce.AuthorizeNetPayment.Core.csproj" />

--- a/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
+++ b/src/VirtoCommerce.AuthorizeNetPayment.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Payment" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Orders" version="3.1009.0" />
+    <dependency id="VirtoCommerce.Payment" version="3.1004.0" />
   </dependencies>
 
   <title>Authorize.Net Payment Method</title>

--- a/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
+++ b/tests/VirtoCommerce.AuthorizeNetPayment.Tests/VirtoCommerce.AuthorizeNetPayment.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 7). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Waves 1–6 packages on nuget.org. Version handled by CI.

- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Payment and Orders module version bumps can surface breaking API or runtime behavior at integration boundaries even when application code is unchanged.
> 
> **Overview**
> Aligns **Authorize.Net Payment** with **Stable 15** by retargeting Virto Commerce dependencies to platform **3.1039.0** and updated Orders/Payment module packages.
> 
> `VirtoCommerce.Platform.Core` moves from **3.1002.0** to **3.1039.0** in Core. Data bumps `VirtoCommerce.OrdersModule.Core` to **3.1009.0** and `VirtoCommerce.PaymentModule.Core` to **3.1004.0**. `module.manifest` updates `platformVersion` and the `VirtoCommerce.Orders` / `VirtoCommerce.Payment` dependency versions to match. The test project bumps `coverlet.collector` from **8.0.0** to **10.0.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89de08d71b5cb10a031951ed9ac6e05a21463947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.AuthorizeNetPayment_3.1003.0-pr-13-89de.zip